### PR TITLE
default variant: use titlescreen or screenshot if cover image is not available

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -248,11 +248,11 @@
                 <zIndex>46</zIndex>
             </text>
 
-             <video name="gamelistbackgroundvideo">
+            <video name="gamelistbackgroundvideo">
                 <pos>0.053 0.6725</pos>
                 <size>0 0.4</size>
                 <origin>0 0.5</origin>
-                <imageType>cover</imageType>
+                <imageType>cover, titlescreen, screenshot</imageType>
                 <delay>2</delay>
                 <zIndex>46</zIndex>
             </video>       


### PR DESCRIPTION
reviewed [the video section](https://gitlab.com/es-de/emulationstation-de/-/blob/master/THEMES-DEV.md#video) in the official ES-DE theme dev documentation and happy to see implementing #2 was quite trivial!

titlescreen is intentionally prioritized over screenshot to be consistent with theme's choice to use game's cover image (when available)

